### PR TITLE
chore: Enforce commit log format

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -108,4 +108,73 @@ Following these guidelines is crucial for facilitating collaboration and onboard
 - **Onboarding**: Helps new team members get up to speed quickly.
 - **Resource**: Serves as a valuable resource for both new and experienced developers.
 
+## Commit Log Format
+
+We enforce a specific format for commit messages to maintain a clear and consistent commit history. We use [Semantic Commit Messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) for our commit log format.
+
+### Commit Message Structure
+
+A commit message consists of a header, a body, and a footer. The header is mandatory and the body and footer are optional.
+
+#### Header
+
+The header has the following format:
+
+```
+<type>: <subject>
+```
+
+- **type**: The type of change (see below for allowed types)
+- **subject**: A brief summary of the change (max 50 characters)
+
+#### Body
+
+The body provides additional information about the change. It should include the motivation for the change and contrast with the previous behavior.
+
+#### Footer
+
+The footer is used to reference issues or breaking changes.
+
+### Allowed Types
+
+We use the following types for commit messages:
+
+- **fix**: A bug fix
+- **feat**: A new feature
+- **change**: A change to existing functionality
+- **refactor**: A code refactoring
+- **upgrade**: An upgrade to dependencies or tools
+- **revert**: A revert of a previous commit
+- **docs**: Documentation changes
+- **style**: Code style changes (formatting, missing semi-colons, etc.)
+- **perf**: Performance improvements
+- **test**: Adding or updating tests
+- **chore**: Other changes that don't modify src or test files
+
+### Example Commit Messages
+
+```
+fix: resolve issue with user login
+
+feat: add new user registration feature
+
+change: update API endpoint for user data
+
+refactor: improve code structure in user service
+
+upgrade: bump version of TypeScript to 4.3.5
+
+revert: undo changes to user authentication
+
+docs: update README with new instructions
+
+style: format code with Prettier
+
+perf: optimize database queries
+
+test: add unit tests for user service
+
+chore: update dependencies
+```
+
 Thank you for contributing to the Mastering API Architecture project! Your efforts are greatly appreciated.

--- a/backend/attendee/.husky/commit-msg
+++ b/backend/attendee/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no-install commitlint --edit "$1"

--- a/backend/attendee/package.json
+++ b/backend/attendee/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
@@ -47,7 +48,10 @@
     "ts-loader": "^9.4.3",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.1.3"
+    "typescript": "^5.1.3",
+    "husky": "^8.0.0",
+    "@commitlint/cli": "^17.0.0",
+    "@commitlint/config-conventional": "^17.0.0"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -65,5 +69,29 @@
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
+  },
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ],
+    "rules": {
+      "type-enum": [
+        2,
+        "always",
+        [
+          "fix",
+          "feat",
+          "change",
+          "refactor",
+          "upgrade",
+          "revert",
+          "docs",
+          "style",
+          "perf",
+          "test",
+          "chore"
+        ]
+      ]
+    }
   }
 }


### PR DESCRIPTION
Fixes #4

Enforce commit log format using husky and document it in `.github/CONTRIBUTING.md`.

* Add husky as a dev dependency and configure it in `backend/attendee/package.json`.
* Create a `commit-msg` hook script in `backend/attendee/.husky/commit-msg` to validate commit messages.
* Update `.github/CONTRIBUTING.md` to include commit log format and prefix list.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/masakazu1967/mastering-api-architecture/pull/7?shareId=4d81339e-9ef5-484a-9355-a982081a6691).